### PR TITLE
Honor openFuturePeriods in periods selector

### DIFF
--- a/core/dhis2Api.js
+++ b/core/dhis2Api.js
@@ -48,7 +48,7 @@ Dhis2Api.factory("Datasets", function($resource, commonvariable) {
             query: {
                 method: "GET",
                 params: {
-                    fields: "id,displayName,periodType,organisationUnits[id,displayName]",
+                    fields: "id,displayName,periodType,openFuturePeriods,organisationUnits[id,displayName]",
                     paging: false
                 },
                 isArray: true,

--- a/directives/form/formController.js
+++ b/directives/form/formController.js
@@ -92,9 +92,11 @@ Dhis2Api.directive('datavaluesForm', function() {
 			 * Populate periods according to dataset
 			 */
 			var populatePeriods = function() {
-					var periods = dhis2.period.generator.generateReversedPeriods($scope.dataset.periodType, $scope.currentPeriodOffset);
-					periods = dhis2.period.generator.filterOpenPeriods($scope.dataset.periodType, periods, 0);
-					$scope.periods = periods;
+					var periodType = $scope.dataset.periodType;
+					var openFuturePeriods = $scope.dataset.openFuturePeriods;
+					var periods = dhis2.period.generator.generateReversedPeriods(periodType, $scope.currentPeriodOffset);
+					var filteredPeriods = dhis2.period.generator.filterOpenPeriods(periodType, periods, openFuturePeriods);
+					$scope.periods = filteredPeriods;
 			};
 			
 			/**


### PR DESCRIPTION
Fixes #32 

With the same logic that _dhis-web-dataentry_: show periods up to `now() + dataset.openFuturePeriods`.

Code deployed to dev.eyeseetea.com:8080